### PR TITLE
Fix bad restore of the protection flags for memory pages when finding real code for hooks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,12 @@ Visual Leak Detector (VLD) Version 2.5.7
 
   Change Log / Release Notes
 
+2.5.8 (1 December 2021)
+----------------------------
+  Bugs Fixed:
+  + Fix AV in FindRealCode due to incorrect restore of page protection flags
+
+
 2.5.7 (10 March 2021)
 ----------------------------
   Bugs Fixed:

--- a/setup/version.h
+++ b/setup/version.h
@@ -1,9 +1,9 @@
 
-#define VLDVERSION          L"2.5.7"
-#define VERSION_NUMBER		2,5,7,0
-#define VERSION_STRING		"2.5.7.0"
-#define VERSION_COPYRIGHT	"Copyright (C) 2005-2020"
+#define VLDVERSION          L"2.5.8"
+#define VERSION_NUMBER		2,5,8,0
+#define VERSION_STRING		"2.5.8.0"
+#define VERSION_COPYRIGHT	"Copyright (C) 2005-2021"
 
 #ifndef __FILE__
-!define VLD_VERSION "2.5.7"	// NSIS Script
+!define VLD_VERSION "2.5.8"	// NSIS Script
 #endif

--- a/setup/vld-setup.iss
+++ b/setup/vld-setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Visual Leak Detector"
-#define MyAppVersion "2.5.7"
+#define MyAppVersion "2.5.8"
 #define MyAppPublisher "VLD Team"
 #define MyAppURL "http://vld.codeplex.com/"
 #define MyAppRegKey "Software\Visual Leak Detector"

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -442,6 +442,8 @@ typedef struct PROTECT_INSTANCE_TAG* PROTECT_HANDLE;
 #define PAGE_MASK 0xFFFFF000
 #endif
 
+#define PAGE_SIZE 0x1000
+
 static BOOL VLDVirtualProtect(PROTECT_HANDLE protect_handle, LPVOID address, SIZE_T size, DWORD protect)
 {
     BOOL result = TRUE;
@@ -457,7 +459,7 @@ static BOOL VLDVirtualProtect(PROTECT_HANDLE protect_handle, LPVOID address, SIZ
     while ((size > 0) && (page_count < MAX_PAGES_PROTECT))
     {
         uintptr_t page_address = current_address & PAGE_MASK;
-        SIZE_T size_in_page = page_address + 0x1000 - current_address;
+        SIZE_T size_in_page = page_address + PAGE_SIZE - current_address;
         SIZE_T size_to_protect = (size_in_page < size) ? size_in_page : size;
 
         result = VirtualProtect((LPVOID)current_address, size_to_protect, protect, &protect_handle->old_protect[page_count]);
@@ -486,7 +488,7 @@ static void VLDVirtualRestore(PROTECT_HANDLE protect_handle)
     while ((size > 0) && (page_count < MAX_PAGES_PROTECT))
     {
         uintptr_t page_address = current_address & PAGE_MASK;
-        SIZE_T size_in_page = page_address + 0x1000 - current_address;
+        SIZE_T size_in_page = page_address + PAGE_SIZE - current_address;
         SIZE_T size_to_protect = (size_in_page < size) ? size_in_page : size;
 
         DWORD dont_care;
@@ -515,7 +517,7 @@ LPVOID FindRealCode(LPVOID pCode)
         // we need to make sure we can read the first 3 ULONG_PTRs
         PROTECT_INSTANCE protect_1;
 
-        if (VLDVirtualProtect(&protect_1, pCode, sizeof(ULONG_PTR) * 6, PAGE_EXECUTE_READ))
+        if (VLDVirtualProtect(&protect_1, pCode, sizeof(ULONG_PTR) * 7, PAGE_EXECUTE_READ))
         {
             if (*(WORD*)pCode == 0x25ff) // JMP r/m32
             {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -447,7 +447,13 @@ LPVOID FindRealCode(LPVOID pCode)
                 if (VirtualProtect(addr, sizeof(LPVOID), PAGE_EXECUTE_READ, &old_protect_2))
                 {
                     result = *(LPVOID*)(addr);
-                    (void)VirtualProtect(addr, sizeof(LPVOID), old_protect_2, &old_protect_2);
+                    if (!VirtualProtect(addr, sizeof(LPVOID), old_protect_2, &old_protect_2))
+                    {
+                        Report(L"VirtualProtect failed for address=%p, size=%zu, with %lu, old_protect_2=%lu",
+                            addr, sizeof(LPVOID),
+                            GetLastError(), old_protect_2);
+                        abort();
+                    }
                 }
                 else
                 {
@@ -461,7 +467,13 @@ LPVOID FindRealCode(LPVOID pCode)
                 {
                     pCode = *(LPVOID*)(addr);
                     result = FindRealCode(pCode);
-                    (void)VirtualProtect((LPVOID*)addr, sizeof(LPVOID), old_protect_2, &old_protect_2);
+                    if (!VirtualProtect((LPVOID*)addr, sizeof(LPVOID), old_protect_2, &old_protect_2))
+                    {
+                        Report(L"VirtualProtect failed for address=%p, size=%zu, with %lu, old_protect_2=%lu",
+                            addr, sizeof(LPVOID),
+                            GetLastError(), old_protect_2);
+                        abort();
+                    }
                 }
                 else
                 {
@@ -483,7 +495,13 @@ LPVOID FindRealCode(LPVOID pCode)
             }
 
             // restore the page protection state
-            (void)VirtualProtect(pCode, sizeof(ULONG_PTR) * 3, old_protect, &old_protect);
+            if (!VirtualProtect(pCode, sizeof(ULONG_PTR) * 3, old_protect, &old_protect))
+            {
+                Report(L"VirtualProtect failed for address=%p, size=%zu, with %lu, old_protect=%lu",
+                    pCode, sizeof(ULONG_PTR) * 3,
+                    GetLastError(), old_protect);
+                abort();
+            }
         }
         else
         {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -460,7 +460,7 @@ static BOOL VLDVirtualProtect(PROTECT_HANDLE protect_handle, LPVOID address, SIZ
         SIZE_T size_in_page = page_address + 0x1000 - current_address;
         SIZE_T size_to_protect = (size_in_page < size) ? size_in_page : size;
 
-        BOOL result = VirtualProtect((LPVOID)current_address, size_to_protect, protect, &protect_handle->old_protect[page_count]);
+        result = VirtualProtect((LPVOID)current_address, size_to_protect, protect, &protect_handle->old_protect[page_count]);
         if (!result)
         {
             Report(L"%zu: !!! VirtualProtect FAILED when protecting for address=%p, size=%zu, with GetLastError()=%lu, protect_handle->address=%p, protect_handle->size=%zu",
@@ -530,8 +530,8 @@ LPVOID FindRealCode(LPVOID pCode)
 
                 if (VLDVirtualProtect(&protect_2, (LPVOID*)addr, sizeof(LPVOID), PAGE_EXECUTE_READ))
                 {
-                    result = *(LPVOID*)(addr);
-
+                    pCode = *(LPVOID*)(addr);
+                    result = FindRealCode(pCode);
                     VLDVirtualRestore(&protect_2);
                 }
                 else
@@ -565,6 +565,10 @@ LPVOID FindRealCode(LPVOID pCode)
                     pCode = (LPVOID*)(pNextInst + offset);
                     result = FindRealCode(pCode);
                     VLDVirtualRestore(&protect_2);
+                }
+                else
+                {
+                    result = NULL;
                 }
             }
             else

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -436,7 +436,7 @@ LPVOID FindRealCode(LPVOID pCode)
         //static volatile size_t fail_line;
         //Report(L"%zu: Calling VirtualProtect(address=%p, size=%zu, PAGE_EXECUTE_READ)\r\n",
         //    __LINE__, pCode, sizeof(ULONG_PTR) * 3);
-        if (((uintptr_t)pCode & 0xFFFFFFFFFFFFF000) == 0x00007ffa4e0e4000) abort();
+        //if (((uintptr_t)pCode & 0xFFFFFFFFFFFFF000) == 0x00007ffa4e0e4000) abort();
         if (VirtualProtect(pCode, sizeof(ULONG_PTR) * 3, PAGE_EXECUTE_READ, &old_protect))
         {
             if (*(WORD*)pCode == 0x25ff) // JMP r/m32
@@ -476,7 +476,7 @@ LPVOID FindRealCode(LPVOID pCode)
                 DWORD old_protect_2;
                 //Report(L"%zu: Calling VirtualProtect(address=%p, size=%zu, PAGE_EXECUTE_READ)\r\n",
                 //    __LINE__, pCode, sizeof(ULONG_PTR) * 3);
-                if ((addr & 0xFFFFFFFFFFFFF000) == 0x00007ffa4e0e4000) abort();
+                //if ((addr & 0xFFFFFFFFFFFFF000) == 0x00007ffa4e0e4000) abort();
                 if (VirtualProtect((LPVOID*)addr, sizeof(LPVOID), PAGE_EXECUTE_READ, &old_protect_2))
                 {
                     pCode = *(LPVOID*)(addr);
@@ -640,6 +640,8 @@ BOOL PatchImport (HMODULE importmodule, moduleentry_t *patchModule)
     while (idte->FirstThunk != 0x0) {
         PCHAR importdllname = (PCHAR)R2VA(importmodule, idte->Name);
         UNREFERENCED_PARAMETER(importdllname);
+        HMODULE importdllbaseaddress = GetModuleHandleA(importdllname);
+        UNREFERENCED_PARAMETER(importdllbaseaddress);
 
         // Locate the import's IAT entry.
         IMAGE_THUNK_DATA *thunk = (IMAGE_THUNK_DATA*)R2VA(importmodule, idte->FirstThunk);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -514,7 +514,7 @@ LPVOID FindRealCode(LPVOID pCode)
     LPVOID result;
     if (pCode != NULL)
     {
-        // we need to make sure we can read the first 3 ULONG_PTRs
+        // we need to make sure we can read the first 7 ULONG_PTRs
         PROTECT_INSTANCE protect_1;
 
         if (VLDVirtualProtect(&protect_1, pCode, sizeof(ULONG_PTR) * 7, PAGE_EXECUTE_READ))


### PR DESCRIPTION
Fix bad restore of the protection flags for memory pages when finding real code for hooks. There were several issues:
- The address passed to the VirtaulProtect call that restores the protection flag could be different than the address originally used to set the page to EXECUTE_READ. This is due to the fact that pCode could be modified between the 2 calls.
- VirtualProtect only returns the old protection flag for the first page. So, should the protected area span 2 pages (highly unlikely but still possible), the second and potentially subsequent pages would have a possibly wrong protection flag restored
- The 64 bit version of the code did not call FindRealCode recursively (unknown why)
- The protected memory area was not big enough in some of the cases

The solution is to have 2 wrapper functions to protect and restore a memory area, which would account for walking multiple pages, saving the proper protection flag to be used when restoring.
