### PR TITLE
Fix for unreported memory leaks with Win32 applications

### DIFF
--- a/lib/cppformat/format.vcxproj
+++ b/lib/cppformat/format.vcxproj
@@ -23,14 +23,14 @@
     <Keyword>Win32Proj</Keyword>
     <Platform>Win32</Platform>
     <ProjectName>libformat</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <RootNamespace>libformat</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/setup/build_version.bat
+++ b/setup/build_version.bat
@@ -5,7 +5,7 @@ TITLE Building VLD...
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 REM Check if the needed files are present
-IF "%VS160COMNTOOLS%"=="" GOTO :BadPaths
+IF "%VS170COMNTOOLS%"=="" GOTO :BadPaths
 
 CD %~dp0/..
 

--- a/setup/vld-setup.iss
+++ b/setup/vld-setup.iss
@@ -7,7 +7,7 @@
 #define MyAppURL "http://vld.codeplex.com/"
 #define MyAppRegKey "Software\Visual Leak Detector"
 #define ConfigType "Release"
-#define PlatformVersion "v142"
+#define PlatformVersion "v143"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -65,7 +65,7 @@ Source: "Microsoft.Cpp.x64.user.props"; DestDir: "{localappdata}\Microsoft\MSBui
 [Tasks]
 Name: "modifypath"; Description: "Add VLD directory to your environmental path"
 Name: "modifyVS2008Props"; Description: "Add VLD directory to VS 2008"
-Name: "modifyVS2010Props"; Description: "Add VLD directory to VS 2010 - VS 2015"
+Name: "modifyVS2010Props"; Description: "Add VLD directory to VS 2010 - VS 2022"
 
 [ThirdParty]
 UseRelativePaths=True

--- a/src/tests/basics/basics.vcxproj
+++ b/src/tests/basics/basics.vcxproj
@@ -55,13 +55,13 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>test_basics</RootNamespace>
     <ProjectName>test_basics</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/corruption/corruption.vcxproj
+++ b/src/tests/corruption/corruption.vcxproj
@@ -54,14 +54,14 @@
     <ProjectGuid>{87911ED6-84BC-4526-9654-A4FF4E0EDF52}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>corruption</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>corruption</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/dynamic_app/dynamic_app.vcxproj
+++ b/src/tests/dynamic_app/dynamic_app.vcxproj
@@ -54,14 +54,14 @@
     <ProjectGuid>{5C25E1C8-00CB-4E0A-9BEC-952F0A6E5DCA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dynamic_app</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>dynamic_app</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/dynamic_dll/dynamic.vcxproj
+++ b/src/tests/dynamic_dll/dynamic.vcxproj
@@ -55,13 +55,13 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dynamic</RootNamespace>
     <ProjectName>dynamic</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/mfc/vldmfc.vcxproj
+++ b/src/tests/mfc/vldmfc.vcxproj
@@ -37,7 +37,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A231973E-072A-428E-982E-5363ADD1CDE2}</ProjectGuid>
     <Keyword>MFCProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>vldmfc</ProjectName>
     <RootNamespace>vldmfc</RootNamespace>
   </PropertyGroup>
@@ -45,7 +45,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseOfMfc>Dynamic</UseOfMfc>

--- a/src/tests/mfc_dll/mfc.vcxproj
+++ b/src/tests/mfc_dll/mfc.vcxproj
@@ -55,13 +55,13 @@
     <RootNamespace>test_mfc</RootNamespace>
     <Keyword>MFCDLLProj</Keyword>
     <ProjectName>test_mfc</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/static_string_test/static_string_test.vcxproj
+++ b/src/tests/static_string_test/static_string_test.vcxproj
@@ -55,13 +55,13 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>static_string_test</RootNamespace>
     <ProjectName>static_string_test</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/suite/testsuite.vcxproj
+++ b/src/tests/suite/testsuite.vcxproj
@@ -53,14 +53,14 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EE4A829C-5FD8-460B-8A90-B518B9BABB70}</ProjectGuid>
     <RootNamespace>testsuite</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>testsuite</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/tests/vld_ComTest/ComTest_vs14.vcxproj
+++ b/src/tests/vld_ComTest/ComTest_vs14.vcxproj
@@ -55,13 +55,13 @@
     <Keyword>AtlProj</Keyword>
     <ProjectName>ComTest</ProjectName>
     <RootNamespace>ComTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/tests/vld_dll1/vld_dll1_vs14.vcxproj
+++ b/src/tests/vld_dll1/vld_dll1_vs14.vcxproj
@@ -55,12 +55,12 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vld_dll1</RootNamespace>
     <ProjectName>vld_dll1</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_dll2/vld_dll2_vs14.vcxproj
+++ b/src/tests/vld_dll2/vld_dll2_vs14.vcxproj
@@ -55,12 +55,12 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vld_dll2</RootNamespace>
     <ProjectName>vld_dll2</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_main/vld_main_vs14.vcxproj
+++ b/src/tests/vld_main/vld_main_vs14.vcxproj
@@ -55,12 +55,12 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vld_main</RootNamespace>
     <ProjectName>vld_main</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_main_test/vld_main_test_vs14.vcxproj
+++ b/src/tests/vld_main_test/vld_main_test_vs14.vcxproj
@@ -55,12 +55,12 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vld_main_test</RootNamespace>
     <ProjectName>vld_main_test</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/tests/vld_unload/vld_unload_vs14.vcxproj
+++ b/src/tests/vld_unload/vld_unload_vs14.vcxproj
@@ -55,12 +55,12 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vld_unload</RootNamespace>
     <ProjectName>vld_unload</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1283,19 +1283,19 @@ HMODULE GetCallingModule(UINT_PTR pCaller )
 {
     HMODULE hModule = NULL;
 
-    /*MEMORY_BASIC_INFORMATION mbi;
+    MEMORY_BASIC_INFORMATION mbi;
     if (VirtualQuery((LPCVOID)pCaller, &mbi, sizeof(MEMORY_BASIC_INFORMATION)) == sizeof(MEMORY_BASIC_INFORMATION))
     {
         // the allocation base is the beginning of a PE file
         hModule = (HMODULE)mbi.AllocationBase;
-    }*/
-
-    WIN32_MEMORY_REGION_INFORMATION memoryRegionInfo;
-    if ( QueryVirtualMemoryInformation(GetCurrentProcess(), (LPCVOID)pCaller, MemoryRegionInfo, &memoryRegionInfo, sizeof(memoryRegionInfo), NULL) )
-    {
-        // the allocation base is the beginning of a PE file
-        hModule = (HMODULE)memoryRegionInfo.AllocationBase;
     }
+
+    //WIN32_MEMORY_REGION_INFORMATION memoryRegionInfo;
+    //if ( QueryVirtualMemoryInformation(GetCurrentProcess(), (LPCVOID)pCaller, MemoryRegionInfo, &memoryRegionInfo, sizeof(memoryRegionInfo), NULL) )
+    //{
+    //    // the allocation base is the beginning of a PE file
+    //    hModule = (HMODULE)memoryRegionInfo.AllocationBase;
+    //}
     return hModule;
 }
 

--- a/src/vld.vcxproj
+++ b/src/vld.vcxproj
@@ -26,13 +26,13 @@
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
     <NumericPlatform Condition="'$(Platform)'=='Win32'">x86</NumericPlatform>
     <NumericPlatform Condition="'$(Platform)'=='x64'">x64</NumericPlatform>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>vld</ProjectName>
   </PropertyGroup>
   <!-- Import Default Property Sheets -->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Global properties -->


### PR DESCRIPTION
I've reverted a change in utility.cpp that caused memory leaks not to be reported in x86 builds.

A simple leak like this: 
```
int main()
{
	int* x = new int {10};
}
```
was not reported, now it is again. 
In the meantime I also updated to vs2022